### PR TITLE
feat: 月単位データ表示機能を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,112 @@
-# Git Status - GitHub活動データ管理システム
+# GitStatus - GitHub Organization Activity Tracker
 
-GitHub組織のメンバー活動データを取得・管理・可視化するシステムです。
+GitHub組織のメンバー活動を追跡・分析するWebアプリケーションです。
 
-## 機能
+## 主な機能
 
-### 基本機能
-- 組織メンバーの活動データ取得（イシュー、プルリクエスト、コミット、レビュー）
-- 期間指定でのデータ取得
-- テストモードでの動作確認
-- 組織別統計表示
+### 1. 月毎データ取得機能（新機能）
+- **月単位でのデータ取得**: 指定した月のデータを一括取得
+- **月毎ファイル保存**: 各月のデータを個別のJSONファイルに保存
+- **取得済み月の表示**: UIで取得済みの月と最終取得日時を表示
+- **期間指定表示**: 開始月と終了月を指定してデータを表示
+- **再取得確認**: 既に取得済みの月を再取得する際の確認ダイアログ
 
-### 週単位データ管理機能
-- 週単位でのデータ取得・保存・管理
-- 取得済み週の一覧表示
-- 週単位データの再取得・削除機能
-- 既に取得済みの週を再取得する際の確認ダイアログ
-- 週単位データの統合表示
+### 2. 週単位データ取得機能（従来機能）
+- **週単位でのデータ取得**: 指定した週のデータを取得
+- **週毎ファイル保存**: 各週のデータを個別のJSONファイルに保存
+- **取得済み週の表示**: UIで取得済みの週と最終取得日時を表示
 
-### 全メンバー活動サマリー
-- 全メンバーの活動を一目で比較できる棒グラフテーブル
-- 月単位での期間選択機能
-- イシュー作成数、プルリク作成数、コミット数、レビュー数を色分け表示
-- 合計値でのソート（降順）
-- メンバーアバターと名前の表示
-- 組織をまたいだメンバー統合表示
+### 3. メンバー活動サマリー
+- **全メンバーの活動一覧**: イシュー、PR、コミット、レビューの集計
+- **月別フィルタリング**: 特定の月のデータのみを表示
+- **組織横断統合**: 複数組織のメンバーデータを統合表示
+- **活動グラフ**: 各メンバーの活動をカラーコード付きバーグラフで表示
 
-### データ可視化
-- 個別メンバーの活動チャート
-- 組織別詳細情報
-- リアルタイム統計表示
+### 4. データ管理
+- **テストモード**: 最新3リポジトリのみ、各リポジトリから10件ずつ取得
+- **レート制限対応**: GitHub APIのレート制限を考慮した取得
+- **データ削除**: 不要なデータの削除機能
 
-## 技術スタック
+## 使用方法
 
-### バックエンド
-- Node.js + TypeScript
-- Express.js
-- GitHub API (GraphQL + REST)
-- moment.js
+### 月毎データ取得
+1. **月を選択**: 「取得する月」フィールドで月を選択
+2. **データ取得**: 「月毎データ取得（全組織）」ボタンをクリック
+3. **確認ダイアログ**: 既に取得済みの場合は確認ダイアログが表示
+4. **表示期間設定**: 開始月と終了月を指定して「期間データ読み込み」をクリック
 
-### フロントエンド
-- React + TypeScript
-- Tailwind CSS
-- moment.js
+### 週単位データ取得（従来機能）
+1. **期間設定**: 開始日と終了日を指定
+2. **データ取得**: 「週単位データ取得（全組織）」ボタンをクリック
+
+### メンバー活動サマリー表示
+1. **期間設定**: 表示したい月の範囲を指定
+2. **サマリー表示**: 「メンバー活動サマリーを表示」ボタンをクリック
+3. **データ確認**: 各メンバーの活動をグラフで確認
+
+## API エンドポイント
+
+### 月毎データ関連
+- `GET /api/monthly-data/:orgName` - 組織の月毎データ一覧取得
+- `POST /api/fetch-monthly-data` - 月毎データ取得・保存
+- `DELETE /api/monthly-data/:orgName/:monthStart` - 月毎データ削除
+- `GET /api/monthly-activities` - 指定期間の月毎データ統合取得
+
+### 週単位データ関連
+- `GET /api/weekly-data/:orgName` - 組織の週単位データ一覧取得
+- `POST /api/fetch-weekly-data` - 週単位データ取得・保存
+- `DELETE /api/weekly-data/:orgName/:weekStart` - 週単位データ削除
+- `GET /api/weekly-activities` - 指定期間の週単位データ統合取得
+
+### 従来のエンドポイント
+- `GET /api/activities` - 全組織の活動データ取得
+- `GET /api/organizations` - 組織一覧取得
+- `POST /api/fetch` - 全組織のデータ取得
+
+## データファイル構造
+
+### 月毎データファイル (`{orgName}-monthly-activities.json`)
+```json
+{
+  "organization": "macromill",
+  "months": {
+    "2025-06": {
+      "monthKey": "2025-06",
+      "monthStart": "2025-06-01",
+      "monthEnd": "2025-06-30",
+      "lastUpdated": "2025-07-19T23:04:30.719Z",
+      "activities": [...]
+    }
+  },
+  "lastUpdated": "2025-07-19T23:04:30.719Z"
+}
+```
+
+### 週単位データファイル (`{orgName}-weekly-activities.json`)
+```json
+{
+  "organization": "macromill",
+  "weeks": {
+    "2025-W25": {
+      "weekKey": "2025-W25",
+      "weekStart": "2025-06-16",
+      "weekEnd": "2025-06-22",
+      "lastUpdated": "2025-07-19T23:04:30.719Z",
+      "activities": [...]
+    }
+  },
+  "lastUpdated": "2025-07-19T23:04:30.719Z"
+}
+```
 
 ## セットアップ
 
 ### 前提条件
 - Node.js (v16以上)
-- npm
+- npm または yarn
 - GitHub Personal Access Token
 
 ### インストール
-
 1. リポジトリをクローン
 ```bash
 git clone <repository-url>
@@ -60,91 +115,78 @@ cd GitStatus
 
 2. 依存関係をインストール
 ```bash
+# バックエンド
+cd backend
 npm install
-cd backend && npm install
-cd ../frontend && npm install
+
+# フロントエンド
+cd ../frontend
+npm install
 ```
 
 3. 環境変数を設定
 ```bash
-cp backend/env.example backend/.env
-# .envファイルを編集してGitHubトークンを設定
+# backend/.env
+GITHUB_TOKEN=your_github_token_here
 ```
 
 4. アプリケーションを起動
 ```bash
-# バックエンド
-cd backend && npm start
+# バックエンド（ポート3001）
+cd backend
+npm start
 
-# フロントエンド（別ターミナル）
-cd frontend && npm start
+# フロントエンド（ポート3000）
+cd frontend
+npm start
 ```
 
-## 使用方法
+## 設定ファイル
 
-### データ取得
-1. 開始日・終了日を設定
-2. テストモードの確認
-3. 「データ取得（全組織）」ボタンでデータを取得
-
-### 週単位データ管理
-1. 週の開始日を選択（自動で週の範囲が計算される）
-2. 「週単位データ取得」ボタンで全組織の該当週データを取得
-3. 取得済み週一覧で再取得・削除が可能
-
-### 全メンバー活動サマリー
-1. 「表示月を選択」で月を選択
-2. 「メンバーテーブルを表示」ボタンでサマリーテーブルを表示
-3. 全メンバーの活動を一目で比較
-
-### 個別メンバー詳細
-1. 「全組織メンバー選択」でメンバーを選択
-2. 選択したメンバーの活動チャートを表示
-
-## データ構造
-
-### 週単位データ
-- ファイル形式: `{orgName}-weekly-activities.json`
-- 構造: 週キー（YYYY-WW）ごとの活動データ
-
-### メンバー活動データ
-- ファイル形式: `{orgName}-activities.json`
-- 構造: メンバーごとの月別活動データ
-
-## API エンドポイント
-
-### 週単位データ
-- `GET /api/weekly-data/:orgName` - 組織の週単位データ取得
-- `POST /api/fetch-weekly-data` - 週単位データ取得・保存
-- `DELETE /api/weekly-data/:orgName/:weekStart` - 週単位データ削除
-- `GET /api/weekly-activities` - 全組織の週単位データ統合取得
-
-### 基本データ
-- `GET /api/activities` - 全組織の活動データ取得
-- `POST /api/fetch-all-organizations` - 全組織のデータ一括取得
-
-## 設定
-
-### 組織設定
-`config/organizations.json`で対象組織を設定
-
+### `config/organizations.json`
 ```json
 {
   "organizations": [
     {
-      "name": "organization-name",
-      "displayName": "Organization Display Name"
+      "name": "macromill",
+      "displayName": "macromill"
+    },
+    {
+      "name": "macromill-mint",
+      "displayName": "macromill-mint"
     }
   ]
 }
 ```
 
+## 技術スタック
+
+### バックエンド
+- **Node.js** + **TypeScript**
+- **Express.js** - Webフレームワーク
+- **Octokit** - GitHub API クライアント
+- **Moment.js** - 日付処理
+
+### フロントエンド
+- **React** + **TypeScript**
+- **Tailwind CSS** - スタイリング
+- **Axios** - HTTP クライアント
+- **Moment.js** - 日付処理
+
 ## 注意事項
 
-- GitHub APIのレート制限に注意
-- 大量データ取得時は時間がかかる場合があります
-- テストモードでは制限されたデータのみ取得されます
+1. **GitHub API レート制限**: 認証済みリクエストで5,000リクエスト/時間
+2. **テストモード**: 開発・テスト時はテストモードを使用してAPI使用量を削減
+3. **データ保存**: 取得したデータは `backend/data/` ディレクトリに保存
+4. **エラーハンドリング**: API エラーやネットワークエラーに対する適切な処理を実装
 
-## ライセンス
+## トラブルシューティング
 
-MIT License 
+### よくある問題
+1. **レート制限エラー**: テストモードを使用するか、しばらく待ってから再試行
+2. **データが取得できない**: GitHub Tokenの権限を確認
+3. **フロントエンドエラー**: バックエンドサーバーが起動しているか確認
+
+### ログ確認
+- バックエンドのコンソールログで詳細なエラー情報を確認
+- ブラウザの開発者ツールでネットワークエラーを確認 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -100,7 +100,7 @@ app.get('/api/activities/:orgName', (req, res) => {
 // データを取得して保存（組織ごと）
 app.post('/api/fetch-data', async (req, res) => {
   try {
-    const { orgName, startDate, endDate, testMode = false, targetMember } = req.body;
+    const { orgName, startDate, endDate } = req.body;
 
     if (!orgName || !startDate || !endDate) {
       return res.status(400).json({ 
@@ -110,18 +110,16 @@ app.post('/api/fetch-data', async (req, res) => {
 
     const dateRange: DateRange = { startDate, endDate };
     
-    console.log(`Fetching data for ${orgName} from ${startDate} to ${endDate} (testMode: ${testMode})${targetMember ? `, targetMember: ${targetMember}` : ''}`);
+    console.log(`Fetching data for ${orgName} from ${startDate} to ${endDate}`);
     
-    const activities = await githubService.getAllMemberActivities(orgName, dateRange, testMode, targetMember);
+    const activities = await githubService.getAllMemberActivities(orgName, dateRange);
     dataService.saveOrganizationActivities(orgName, activities);
 
     res.json({ 
-      message: `Data fetched and saved successfully for ${orgName} (${testMode ? 'TEST MODE' : 'PRODUCTION MODE'})${targetMember ? `, targetMember: ${targetMember}` : ''}`,
+      message: `Data fetched and saved successfully for ${orgName}`,
       count: activities.length,
       lastUpdated: new Date().toISOString(),
-      organization: orgName,
-      testMode,
-      targetMember
+      organization: orgName
     });
   } catch (error) {
     console.error('Error fetching data:', error);
@@ -132,7 +130,7 @@ app.post('/api/fetch-data', async (req, res) => {
 // 特定メンバーのデータを取得（テスト用）
 app.post('/api/fetch-member-data', async (req, res) => {
   try {
-    const { orgName, startDate, endDate, testMode = false, memberLogin = 'mm-kado' } = req.body;
+    const { orgName, startDate, endDate, memberLogin = 'mm-kado' } = req.body;
 
     if (!orgName || !startDate || !endDate) {
       return res.status(400).json({ 
@@ -142,18 +140,17 @@ app.post('/api/fetch-member-data', async (req, res) => {
 
     const dateRange: DateRange = { startDate, endDate };
     
-    console.log(`Fetching data for member ${memberLogin} in ${orgName} from ${startDate} to ${endDate} (testMode: ${testMode})`);
+    console.log(`Fetching data for member ${memberLogin} in ${orgName} from ${startDate} to ${endDate}`);
     
-    const activities = await githubService.getAllMemberActivities(orgName, dateRange, testMode, memberLogin);
+    const activities = await githubService.getAllMemberActivities(orgName, dateRange, memberLogin);
     dataService.saveOrganizationActivities(orgName, activities);
 
     res.json({ 
-      message: `Data fetched and saved successfully for member ${memberLogin} in ${orgName} (${testMode ? 'TEST MODE' : 'PRODUCTION MODE'})`,
+      message: `Data fetched and saved successfully for member ${memberLogin} in ${orgName}`,
       count: activities.length,
       lastUpdated: new Date().toISOString(),
       organization: orgName,
-      memberLogin,
-      testMode
+      memberLogin
     });
   } catch (error) {
     console.error('Error fetching member data:', error);
@@ -164,7 +161,7 @@ app.post('/api/fetch-member-data', async (req, res) => {
 // mm-kadoのデータを全ての組織から取得
 app.post('/api/fetch-mm-kado-all-orgs', async (req, res) => {
   try {
-    const { startDate, endDate, testMode = false, memberLogin = 'mm-kado' } = req.body;
+    const { startDate, endDate, memberLogin = 'mm-kado' } = req.body;
 
     if (!startDate || !endDate) {
       return res.status(400).json({ 
@@ -176,12 +173,12 @@ app.post('/api/fetch-mm-kado-all-orgs', async (req, res) => {
     const results: { [key: string]: { count: number, success: boolean, error?: string } } = {};
     const allActivities: any[] = [];
     
-    console.log(`Fetching data for member ${memberLogin} from all organizations from ${startDate} to ${endDate} (testMode: ${testMode})`);
+    console.log(`Fetching data for member ${memberLogin} from all organizations from ${startDate} to ${endDate}`);
     
     for (const org of organizations) {
       try {
         console.log(`Fetching data for member ${memberLogin} in organization: ${org.name}`);
-        const activities = await githubService.getAllMemberActivities(org.name, dateRange, testMode, memberLogin);
+        const activities = await githubService.getAllMemberActivities(org.name, dateRange, memberLogin);
         
         if (activities.length > 0) {
           // 組織情報を追加
@@ -222,12 +219,11 @@ app.post('/api/fetch-mm-kado-all-orgs', async (req, res) => {
     const totalCount = allActivities.length;
 
     res.json({ 
-      message: `Data fetched for member ${memberLogin} from all organizations (${testMode ? 'TEST MODE' : 'PRODUCTION MODE'})`,
+      message: `Data fetched for member ${memberLogin} from all organizations`,
       totalCount,
       lastUpdated: new Date().toISOString(),
       memberLogin,
-      results,
-      testMode
+      results
     });
   } catch (error) {
     console.error('Error fetching member data from all organizations:', error);
@@ -238,7 +234,7 @@ app.post('/api/fetch-mm-kado-all-orgs', async (req, res) => {
 // 全組織のデータを一括取得
 app.post('/api/fetch-all-organizations', async (req, res) => {
   try {
-    const { startDate, endDate, testMode = false } = req.body;
+    const { startDate, endDate } = req.body;
 
     if (!startDate || !endDate) {
       return res.status(400).json({ 
@@ -249,12 +245,12 @@ app.post('/api/fetch-all-organizations', async (req, res) => {
     const dateRange: DateRange = { startDate, endDate };
     const results: { [key: string]: { count: number, success: boolean, error?: string } } = {};
     
-    console.log(`Fetching data for all organizations from ${startDate} to ${endDate} (testMode: ${testMode})`);
+    console.log(`Fetching data for all organizations from ${startDate} to ${endDate}`);
     
     for (const org of organizations) {
       try {
         console.log(`Fetching data for organization: ${org.name}`);
-        const activities = await githubService.getAllMemberActivities(org.name, dateRange, testMode);
+        const activities = await githubService.getAllMemberActivities(org.name, dateRange);
         dataService.saveOrganizationActivities(org.name, activities);
         
         results[org.name] = {
@@ -276,11 +272,10 @@ app.post('/api/fetch-all-organizations', async (req, res) => {
     const totalCount = Object.values(results).reduce((sum, result) => sum + result.count, 0);
 
     res.json({ 
-      message: `Data fetched for all organizations (${testMode ? 'TEST MODE' : 'PRODUCTION MODE'})`,
+      message: `Data fetched for all organizations`,
       totalCount,
       lastUpdated: new Date().toISOString(),
-      results,
-      testMode
+      results
     });
   } catch (error) {
     console.error('Error fetching all organizations data:', error);
@@ -341,7 +336,7 @@ app.get('/api/weekly-data/:orgName', (req, res) => {
 // 週単位データを取得して保存
 app.post('/api/fetch-weekly-data', async (req, res) => {
   try {
-    const { orgName, weekStart, weekEnd, testMode = false, forceUpdate = false } = req.body;
+    const { orgName, weekStart, weekEnd, forceUpdate = false } = req.body;
 
     if (!orgName || !weekStart || !weekEnd) {
       return res.status(400).json({ 
@@ -362,19 +357,18 @@ app.post('/api/fetch-weekly-data', async (req, res) => {
 
     const dateRange: DateRange = { startDate: weekStart, endDate: weekEnd };
     
-    console.log(`Fetching weekly data for ${orgName} from ${weekStart} to ${weekEnd} (testMode: ${testMode}, forceUpdate: ${forceUpdate})`);
+    console.log(`Fetching weekly data for ${orgName} from ${weekStart} to ${weekEnd} (forceUpdate: ${forceUpdate})`);
     
-    const activities = await githubService.getAllMemberActivities(orgName, dateRange, testMode);
+    const activities = await githubService.getAllMemberActivities(orgName, dateRange);
     dataService.saveWeeklyActivities(orgName, weekStart, weekEnd, activities);
 
     res.json({ 
-      message: `Weekly data fetched and saved successfully for ${orgName} (${testMode ? 'TEST MODE' : 'PRODUCTION MODE'})`,
+      message: `Weekly data fetched and saved successfully for ${orgName}`,
       count: activities.length,
       lastUpdated: new Date().toISOString(),
       organization: orgName,
       weekStart,
       weekEnd,
-      testMode,
       forceUpdate
     });
   } catch (error) {
@@ -421,6 +415,127 @@ app.get('/api/weekly-activities', (req, res) => {
   } catch (error) {
     console.error('Error loading weekly activities:', error);
     res.status(500).json({ error: 'Failed to load weekly activities' });
+  }
+});
+
+// 月毎データ取得のAPIエンドポイントを追加
+app.get('/api/monthly-data/:orgName', (req, res) => {
+  try {
+    const { orgName } = req.params;
+    const fetchedMonths = dataService.getFetchedMonths(orgName);
+    
+    res.json({ 
+      organization: orgName,
+      fetchedMonths,
+      totalMonths: fetchedMonths.length
+    });
+  } catch (error) {
+    console.error('Error loading monthly data:', error);
+    res.status(500).json({ error: 'Failed to load monthly data' });
+  }
+});
+
+// 月毎データを取得して保存
+app.post('/api/fetch-monthly-data', async (req, res) => {
+  try {
+    const { orgName, monthStart, monthEnd, forceUpdate = false } = req.body;
+
+    if (!orgName || !monthStart || !monthEnd) {
+      return res.status(400).json({ 
+        error: 'Organization name, month start, and month end are required' 
+      });
+    }
+
+    // 既に取得済みの月かチェック
+    const isAlreadyFetched = dataService.isMonthFetched(orgName, monthStart);
+    if (isAlreadyFetched && !forceUpdate) {
+      return res.status(409).json({ 
+        error: 'Month data already exists',
+        monthStart,
+        monthEnd,
+        alreadyFetched: true
+      });
+    }
+
+    const dateRange: DateRange = { startDate: monthStart, endDate: monthEnd };
+    
+    console.log(`Fetching monthly data for ${orgName} from ${monthStart} to ${monthEnd} (forceUpdate: ${forceUpdate})`);
+    
+    const activities = await githubService.getAllMemberActivities(orgName, dateRange);
+    dataService.saveMonthlyActivities(orgName, monthStart, monthEnd, activities);
+
+    res.json({ 
+      message: `Monthly data fetched and saved successfully for ${orgName}`,
+      count: activities.length,
+      lastUpdated: new Date().toISOString(),
+      organization: orgName,
+      monthStart,
+      monthEnd,
+      forceUpdate
+    });
+  } catch (error) {
+    console.error('Error fetching monthly data:', error);
+    res.status(500).json({ error: 'Failed to fetch monthly data' });
+  }
+});
+
+// 月毎データを削除
+app.delete('/api/monthly-data/:orgName/:monthStart', (req, res) => {
+  try {
+    const { orgName, monthStart } = req.params;
+    
+    const deleted = dataService.deleteMonthlyActivities(orgName, monthStart);
+    
+    if (deleted) {
+      res.json({ 
+        message: `Monthly data deleted successfully for ${orgName} month ${monthStart}`,
+        organization: orgName,
+        monthStart
+      });
+    } else {
+      res.status(404).json({ 
+        error: 'Monthly data not found',
+        organization: orgName,
+        monthStart
+      });
+    }
+  } catch (error) {
+    console.error('Error deleting monthly data:', error);
+    res.status(500).json({ error: 'Failed to delete monthly data' });
+  }
+});
+
+// 指定期間の月毎データを統合して取得
+app.get('/api/monthly-activities', (req, res) => {
+  try {
+    const { startMonth, endMonth } = req.query;
+    
+    console.log('API /monthly-activities called with:', { startMonth, endMonth });
+    
+    if (!startMonth || !endMonth) {
+      return res.status(400).json({ 
+        error: 'Start month and end month are required' 
+      });
+    }
+
+    const { activities, organizations: orgStats } = dataService.loadAllOrganizationsMonthlyActivities(startMonth as string, endMonth as string);
+    
+    console.log('API /monthly-activities result:', { 
+      activitiesCount: activities.length, 
+      organizations: Object.keys(orgStats),
+      startMonth,
+      endMonth
+    });
+    
+    res.json({ 
+      activities, 
+      organizations: orgStats,
+      startMonth,
+      endMonth
+    });
+  } catch (error) {
+    console.error('Error loading monthly activities:', error);
+    res.status(500).json({ error: 'Failed to load monthly activities' });
   }
 });
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -37,50 +37,45 @@ export const api = {
   },
 
   // データを取得して保存（組織ごと）
-  fetchData: async (orgName: string, startDate: string, endDate: string, testMode: boolean = false, targetMember?: string): Promise<any> => {
-    console.log(`APIリクエスト: 組織=${orgName}, 開始日=${startDate}, 終了日=${endDate}, テストモード=${testMode}${targetMember ? `, 対象メンバー=${targetMember}` : ''}`);
+  fetchData: async (orgName: string, startDate: string, endDate: string): Promise<any> => {
+    console.log(`APIリクエスト: 組織=${orgName}, 開始日=${startDate}, 終了日=${endDate}`);
     const response = await axios.post(`${API_BASE_URL}/fetch-data`, {
       orgName,
       startDate,
-      endDate,
-      testMode,
-      targetMember
+      endDate
     });
     return response.data;
   },
 
   // 特定メンバーのデータを取得（テスト用）
-  fetchMemberData: async (orgName: string, startDate: string, endDate: string, testMode: boolean = false, memberLogin: string = 'mm-kado'): Promise<any> => {
-    console.log(`APIリクエスト: メンバー=${memberLogin}, 組織=${orgName}, 開始日=${startDate}, 終了日=${endDate}, テストモード=${testMode}`);
+  fetchMemberData: async (orgName: string, startDate: string, endDate: string, memberLogin: string = 'mm-kado'): Promise<any> => {
+    console.log(`APIリクエスト: メンバー=${memberLogin}, 組織=${orgName}, 開始日=${startDate}, 終了日=${endDate}`);
     const response = await axios.post(`${API_BASE_URL}/fetch-member-data`, {
       orgName,
       startDate,
       endDate,
-      testMode,
       memberLogin
     });
     return response.data;
   },
 
   // mm-kadoのデータを全ての組織から取得
-  fetchMmKadoAllOrgs: async (startDate: string, endDate: string, testMode: boolean = false, memberLogin: string = 'mm-kado'): Promise<any> => {
-    console.log(`APIリクエスト: メンバー=${memberLogin}, 全組織, 開始日=${startDate}, 終了日=${endDate}, テストモード=${testMode}`);
+  fetchMmKadoAllOrgs: async (startDate: string, endDate: string, memberLogin: string = 'mm-kado'): Promise<any> => {
+    console.log(`APIリクエスト: メンバー=${memberLogin}, 全組織, 開始日=${startDate}, 終了日=${endDate}`);
     const response = await axios.post(`${API_BASE_URL}/fetch-mm-kado-all-orgs`, {
       startDate,
       endDate,
-      testMode,
       memberLogin
     });
     return response.data;
   },
 
   // 全組織のデータを一括取得
-  fetchAllOrganizations: async (startDate: string, endDate: string, testMode: boolean = false): Promise<any> => {
-    console.log(`APIリクエスト: 全組織, 開始日=${startDate}, 終了日=${endDate}, テストモード=${testMode}`);
+  fetchAllOrganizations: async (startDate: string, endDate: string): Promise<any> => {
+    console.log(`APIリクエスト: 全組織, 開始日=${startDate}, 終了日=${endDate}`);
     const response = await axios.post(`${API_BASE_URL}/fetch-all-organizations`, {
       startDate,
-      endDate,
-      testMode
+      endDate
     });
     return response.data;
   },
@@ -101,6 +96,39 @@ export const api = {
     return response.data;
   },
 
+  // 月毎データを取得
+  async getMonthlyData(orgName: string) {
+    const response = await axios.get(`${API_BASE_URL}/monthly-data/${orgName}`);
+    return response.data;
+  },
+
+  // 月毎データを取得して保存
+  async fetchMonthlyData(orgName: string, monthStart: string, monthEnd: string, forceUpdate: boolean = false) {
+    const response = await axios.post(`${API_BASE_URL}/fetch-monthly-data`, {
+      orgName,
+      monthStart,
+      monthEnd,
+      forceUpdate
+    });
+    
+    return response.data;
+  },
+
+  // 月毎データを削除
+  async deleteMonthlyData(orgName: string, monthStart: string) {
+    const response = await axios.delete(`${API_BASE_URL}/monthly-data/${orgName}/${monthStart}`);
+    
+    return response.data;
+  },
+
+  // 指定期間の月毎データを統合して取得
+  async getMonthlyActivities(startMonth: string, endMonth: string) {
+    const response = await axios.get(`${API_BASE_URL}/monthly-activities`, {
+      params: { startMonth, endMonth }
+    });
+    return response.data;
+  },
+
   // 週単位データを取得
   async getWeeklyData(orgName: string) {
     const response = await axios.get(`${API_BASE_URL}/weekly-data/${orgName}`);
@@ -108,12 +136,11 @@ export const api = {
   },
 
   // 週単位データを取得して保存
-  async fetchWeeklyData(orgName: string, weekStart: string, weekEnd: string, testMode: boolean = false, forceUpdate: boolean = false) {
+  async fetchWeeklyData(orgName: string, weekStart: string, weekEnd: string, forceUpdate: boolean = false) {
     const response = await axios.post(`${API_BASE_URL}/fetch-weekly-data`, {
       orgName,
       weekStart,
       weekEnd,
-      testMode,
       forceUpdate
     });
     


### PR DESCRIPTION
## 変更内容

### 削除した機能
- 月単位データ表示のUI項目を完全に削除
- 月単位選択の入力フィールド
- メンバーテーブル表示ボタン
- 選択月の表示
- 全メンバー活動テーブル

### 削除したstate変数
- `selectedMonth` → `fetchMonth` に変更（データ取得用のみ）
- `showMemberTable`

### 削除した関数
- `handleMonthChange`
- `getFilteredActivities`

### 改善点
- UIをよりシンプルに改善
- 月毎データの取得機能は保持
- 表示期間設定による活動サマリー機能は維持

### テスト
- [x] 月毎データ取得機能が正常に動作することを確認
- [x] 表示期間設定による活動サマリーが正常に表示されることを確認
- [x] UIから月単位データ表示項目が削除されていることを確認