### PR TITLE
feat: GitHub APIレートリミットチェック機能とダイアログ表示を追加

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -308,7 +308,7 @@ app.get('/api/organizations/stats', (req, res) => {
 // レートリミット情報を取得
 app.get('/api/rate-limit', async (req, res) => {
   try {
-    const rateLimitInfo = githubService.getRateLimitInfo();
+    const rateLimitInfo = await githubService.fetchRateLimitInfo();
     res.json({ rateLimitInfo });
   } catch (error) {
     console.error('Error fetching rate limit info:', error);

--- a/backend/src/services/githubService.ts
+++ b/backend/src/services/githubService.ts
@@ -913,8 +913,29 @@ export class GitHubService {
     return memberActivities;
   }
 
-  // レート制限情報を取得
+  // レート制限情報を取得（キャッシュされた情報）
   getRateLimitInfo(): RateLimitInfo | null {
     return this.rateLimitInfo;
+  }
+
+  // GitHub APIから直接レートリミット情報を取得
+  async fetchRateLimitInfo(): Promise<RateLimitInfo> {
+    try {
+      const response = await axios.get(`${this.baseURL}/rate_limit`, {
+        headers: this.getHeaders()
+      });
+      
+      const rateLimit = response.data.resources.core;
+      this.rateLimitInfo = {
+        limit: rateLimit.limit,
+        remaining: rateLimit.remaining,
+        reset: rateLimit.reset
+      };
+      
+      return this.rateLimitInfo;
+    } catch (error) {
+      console.error('Error fetching rate limit info:', error);
+      throw error;
+    }
   }
 } 


### PR DESCRIPTION
## 変更内容

### 追加機能
- **月毎データ取得前のレートリミットチェック**: 残りリクエスト数が2,000以下の場合、処理を中断
- **レートリミット警告ダイアログ**: 現在の使用状況、リセット時刻、リセットまでの時間を表示
- **最新レートリミット情報の取得**: GitHub APIから直接最新情報を取得する機能を追加

### 技術的改善
- **GitHubService.fetchRateLimitInfo()**: GitHub APIから直接レートリミット情報を取得
- **バックエンドAPI更新**: /api/rate-limitエンドポイントで最新情報を取得
- **フロントエンド統合**: App.tsxにレートリミットチェック機能を統合

### UI改善
- 警告ダイアログの情報を縦並びで表示
- 「リクエスト残り」の冗長な文字を削除して簡潔に表示
- 視覚的に分かりやすい警告アイコンと色分け

### 動作フロー
1. 月毎データ取得ボタン押下時にレートリミットチェック
2. 残りリクエスト数が2,000以下の場合、警告ダイアログを表示
3. ダイアログで現在の状況と回復時間を表示
4. ユーザーが「了解」ボタンでダイアログを閉じる

### 修正された問題
- **レートリミット情報の更新問題**: キャッシュされた情報ではなく、GitHub APIから直接最新情報を取得するように修正
- **更新ボタンの動作**: 「更新」ボタンを押すと最新のレートリミット情報が取得されるように改善

### テスト
- [x] レートリミットチェック機能が正常に動作することを確認
- [x] 警告ダイアログが適切に表示されることを確認
- [x] 更新ボタンで最新情報が取得されることを確認
- [x] ダイアログのレイアウトが縦並びで表示されることを確認