### PR TITLE
feat: GitHub APIレートリミットをデータ管理セクション内に移動

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -408,6 +408,11 @@ function App() {
               </div>
             </div>
 
+            {/* GitHub API レートリミット */}
+            <div className="mb-8">
+              <RateLimitDisplay />
+            </div>
+
             {/* 取得済みデータ表示 */}
             <div>
               <h3 className="text-xl font-medium mb-4">取得済みデータ</h3>
@@ -635,10 +640,6 @@ function App() {
 
         {/* メンバー活動サマリー */}
         
-        {/* GitHub API レートリミット */}
-        <div className="mt-8">
-          <RateLimitDisplay />
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 変更内容

### UI改善
- **GitHub APIレートリミットの移動**: ページ下部から「データ管理」セクション内に移動
- **配置の最適化**: 「取得済みデータ」の上に表示するように配置
- **重複表示の削除**: ページ下部の重複していたレートリミット表示を削除

### 改善点
- **関連情報の統合**: データ管理に関連する情報（月毎データ取得、レートリミット、取得済みデータ）を一箇所にまとめて表示
- **ユーザビリティの向上**: データ取得前にレートリミット状況を確認しやすくなった
- **UIの一貫性**: データ管理に関する情報が論理的にグループ化された

### 表示順序
1. 月毎データ取得
2. GitHub API レートリミット
3. 取得済みデータ

### テスト
- [x] レートリミット表示が「データ管理」セクション内に正しく表示されることを確認
- [x] ページ下部の重複表示が削除されていることを確認
- [x] レートリミットの更新機能が正常に動作することを確認