### PR TITLE
feat: CSVダウンロード機能の追加と組織名表示の修正

### DIFF
--- a/backend/src/services/githubService.ts
+++ b/backend/src/services/githubService.ts
@@ -7,7 +7,8 @@ import {
   GitHubCommit, 
   GitHubReview,
   MemberActivity,
-  DateRange 
+  DateRange,
+  Organization
 } from '../types';
 import { graphql } from '@octokit/graphql';
 
@@ -923,10 +924,17 @@ export class GitHubService {
 
       // レビューはGraphQLで既に集計済みのため、ここでの処理を削除
 
+      // 組織の表示名を取得
+      const organizations: Organization[] = require('../../../config/organizations.json').organizations;
+      const orgConfig = organizations.find(org => org.name === orgName);
+      const displayName = orgConfig ? orgConfig.displayName : orgName;
+
       memberActivities.push({
         login: member.login,
         name: member.name,
         avatar_url: member.avatar_url,
+        organization: orgName,
+        organizationDisplayName: displayName,
         activities
       });
     }


### PR DESCRIPTION
## 変更内容

### 新機能
- 全メンバー活動サマリーにCSVダウンロード機能を追加
- CSVフォーマット: メンバー名, 年月, 組織, イシュー作成数, プルリク作成数, コミット数, レビュー数, 合計
- CSVソート順: 名前 → 組織 → 日付（新しい順）

### 修正
- 既存データファイルにorganizationとorganizationDisplayNameフィールドを追加
- GitHubServiceで組織名と表示名を正しく設定するように修正
- 「不明の組織」表示の問題を解決

### 技術的詳細
- MemberActivityTableコンポーネントにCSVダウンロード機能を実装
- データファイル更新スクリプトを作成・実行して既存データを修正
- GitHubServiceで組織設定ファイルから表示名を取得するように改善

### テスト
- 既存の14個のデータファイルを正常に更新
- macromillとmacromill-mintの組織名が正しく設定されることを確認