### PR TITLE
feat: メンバー比較機能の追加と重複除去の修正

### DIFF
--- a/backend/src/mcpServer.ts
+++ b/backend/src/mcpServer.ts
@@ -60,13 +60,13 @@ export class GitStatusMCPServer {
     return [
       {
         name: "query_member_activities",
-        description: "自然言語でメンバー活動を検索します。メンバー名、組織名、活動タイプ、期間などを指定できます。",
+        description: "自然言語でメンバー活動を検索します。メンバー名、組織名、活動タイプ、期間などを指定できます。メンバー比較や組織比較も可能です。",
         inputSchema: {
           type: "object",
           properties: {
             query: {
               type: "string",
-              description: "自然言語クエリ（例: 'mm-kadoの活動を表示して', '最も活動したメンバー上位5人'）"
+              description: "自然言語クエリ（例: 'mm-kadoの活動を表示して', '最も活動したメンバー上位5人', 'mm-kadoとmm-rayyanの活動を比較して', 'macromillとmacromill-mintを比較して'）"
             }
           },
           required: ["query"]

--- a/frontend/src/components/NaturalLanguageQuery.tsx
+++ b/frontend/src/components/NaturalLanguageQuery.tsx
@@ -29,6 +29,7 @@ export const NaturalLanguageQuery: React.FC<NaturalLanguageQueryProps> = ({ onQu
     'mm-kadoの活動を表示して',
     '最も活動したメンバー上位5人',
     'macromillとmacromill-mintを比較して',
+    'mm-kadoとmm-rayyanの活動を比較して',
     '活動を分析して',
     'イシュー数が多いメンバー上位10人',
     'コミット数でソートして',
@@ -155,48 +156,86 @@ export const NaturalLanguageQuery: React.FC<NaturalLanguageQueryProps> = ({ onQu
     const summary = data.summary;
     const insights = data.insights;
 
+    // メンバー比較か組織比較かを判定
+    const isMemberComparison = Array.isArray(comparison) && comparison.length > 0 && comparison[0].member;
+
     return (
       <div className="space-y-6">
         {/* 比較結果 */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {Array.isArray(comparison) && comparison.map((org, index) => (
+          {Array.isArray(comparison) && comparison.map((item, index) => (
             <div key={index} className="bg-white border border-gray-200 rounded-lg p-6">
-              <h3 className="text-lg font-semibold mb-4">{org.organizationDisplayName || org.organization}</h3>
+              <h3 className="text-lg font-semibold mb-4">
+                {isMemberComparison ? item.displayName : (item.organizationDisplayName || item.organization)}
+              </h3>
               <div className="space-y-2">
-                <div className="flex justify-between">
-                  <span>メンバー数:</span>
-                  <span className="font-semibold">{org.memberCount}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>イシュー:</span>
-                  <span className="font-semibold">{org.issues}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>プルリク:</span>
-                  <span className="font-semibold">{org.pullRequests}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>コミット:</span>
-                  <span className="font-semibold">{org.commits}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>レビュー:</span>
-                  <span className="font-semibold">{org.reviews}</span>
-                </div>
-                <div className="flex justify-between border-t pt-2">
-                  <span className="font-semibold">合計:</span>
-                  <span className="font-bold text-lg">{org.total}</span>
-                </div>
-                {/* 平均値も表示 */}
-                <div className="border-t pt-2 mt-2">
-                  <p className="text-sm text-gray-600 mb-1">1人あたりの平均:</p>
-                  <div className="grid grid-cols-2 gap-2 text-xs">
-                    <div>イシュー: {org.averageIssues?.toFixed(1) || 'N/A'}</div>
-                    <div>プルリク: {org.averagePRs?.toFixed(1) || 'N/A'}</div>
-                    <div>コミット: {org.averageCommits?.toFixed(1) || 'N/A'}</div>
-                    <div>レビュー: {org.averageReviews?.toFixed(1) || 'N/A'}</div>
-                  </div>
-                </div>
+                {isMemberComparison ? (
+                  // メンバー比較の場合
+                  <>
+                    <div className="flex justify-between">
+                      <span>組織:</span>
+                      <span className="font-semibold">{item.organization}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>イシュー:</span>
+                      <span className="font-semibold">{item.issues}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>プルリク:</span>
+                      <span className="font-semibold">{item.pullRequests}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>コミット:</span>
+                      <span className="font-semibold">{item.commits}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>レビュー:</span>
+                      <span className="font-semibold">{item.reviews}</span>
+                    </div>
+                    <div className="flex justify-between border-t pt-2">
+                      <span className="font-semibold">合計:</span>
+                      <span className="font-bold text-lg">{item.total}</span>
+                    </div>
+                  </>
+                ) : (
+                  // 組織比較の場合
+                  <>
+                    <div className="flex justify-between">
+                      <span>メンバー数:</span>
+                      <span className="font-semibold">{item.memberCount}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>イシュー:</span>
+                      <span className="font-semibold">{item.issues}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>プルリク:</span>
+                      <span className="font-semibold">{item.pullRequests}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>コミット:</span>
+                      <span className="font-semibold">{item.commits}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>レビュー:</span>
+                      <span className="font-semibold">{item.reviews}</span>
+                    </div>
+                    <div className="flex justify-between border-t pt-2">
+                      <span className="font-semibold">合計:</span>
+                      <span className="font-bold text-lg">{item.total}</span>
+                    </div>
+                    {/* 平均値も表示 */}
+                    <div className="border-t pt-2 mt-2">
+                      <p className="text-sm text-gray-600 mb-1">1人あたりの平均:</p>
+                      <div className="grid grid-cols-2 gap-2 text-xs">
+                        <div>イシュー: {item.averageIssues?.toFixed(1) || 'N/A'}</div>
+                        <div>プルリク: {item.averagePRs?.toFixed(1) || 'N/A'}</div>
+                        <div>コミット: {item.averageCommits?.toFixed(1) || 'N/A'}</div>
+                        <div>レビュー: {item.averageReviews?.toFixed(1) || 'N/A'}</div>
+                      </div>
+                    </div>
+                  </>
+                )}
               </div>
             </div>
           ))}


### PR DESCRIPTION
## 概要

このPRでは、メンバー間比較機能を追加し、複数組織に存在するメンバーのデータを正しく処理できるようにしました。

## 主な変更点

### メンバー比較機能の追加
- メンバー間比較機能を実装（例: ）
- 複数組織に存在するメンバーのデータを正しく合計
- メンバー比較用のインサイト生成機能を追加

### 重複除去の修正
- メンバー抽出時の重複を除去するように修正
- メソッドでSetを使用して重複を除去
- UIでの重複表示問題を解決

### フロントエンド改善
- でメンバー比較と組織比較の両方に対応
- メンバー比較時の表示レイアウトを最適化
- 組織情報の表示を改善（複数組織の場合はカンマ区切りで表示）

### MCPサーバー更新
- ツール説明にメンバー比較機能を追加
- サンプルクエリにメンバー比較の例を追加

## 技術的な詳細

### バックエンド修正
- メソッドでメンバー比較ロジックを追加
- メソッドでメンバー比較用のインサイト生成
- メソッドで重複除去を実装

### フロントエンド修正
- メンバー比較と組織比較を自動判定
- 動的なレイアウト切り替え
- 複数組織の表示対応

## 使用例

### メンバー比較
- 
- 

### 組織比較（既存）
- 

## 修正された問題

1. **mm-rayyanの活動数が正しく表示されない問題**
   - 複数組織のデータを合計するように修正
   - 正しい活動数: イシュー290件、プルリク294件、コミット134件、レビュー209件

2. **UIで同じ情報が2回表示される問題**
   - メンバー抽出時の重複を除去
   - 各メンバーの情報が1回のみ表示されるように修正

## テスト

- メンバー比較機能の動作確認済み
- 複数組織データの合計処理を確認
- 重複除去の動作を確認
- UI表示の正常性を確認